### PR TITLE
feat: 🚀 Add sourceImageParser config option

### DIFF
--- a/__tests__/components/image/config/config.js
+++ b/__tests__/components/image/config/config.js
@@ -2,12 +2,26 @@
  * @type {import('../../../../src').Config}
  */
 const config = {
-  basePath: '/base-path',
-  imageDir: '_custom-optimize',
-  filenameGenerator: ({ path, name, width, quality, extension }) => `${path}-${name}.${width}.${quality}.${extension}`,
-  convertFormat: [
-    ['png', 'webp']
-  ]
-}
+  basePath: "/base-path",
+  imageDir: "_custom-optimize",
+  sourceImageParser: ({ src, defaultParser }) => {
+    const regExpMatches = src.match(/^.*(\/.*)\/([^\/.]*)&ext=(\w\w*)$/);
 
-module.exports = config
+    // if the src has &ext in the route then it is identified
+    // as an image w/ the alternate format
+    if (!regExpMatches) {
+      return defaultParser(src);
+    }
+
+    return {
+      pathWithoutName: regExpMatches[1] || "",
+      name: regExpMatches[2] || "",
+      extension: regExpMatches[3] || "",
+    };
+  },
+  filenameGenerator: ({ path, name, width, quality, extension }) =>
+    `${path}-${name}.${width}.${quality}.${extension}`,
+  convertFormat: [["png", "webp"]],
+};
+
+module.exports = config;

--- a/__tests__/components/image/config/index.test.tsx
+++ b/__tests__/components/image/config/index.test.tsx
@@ -9,8 +9,8 @@ import React from 'react'
 import CustomImage from '../../../../src/image'
 
 describe('Apply config', () => {
-  test('Set `imageDir` and `filenameGenerator` and `convetFormat`', () => {
-    render(<CustomImage src="/images/img.png" width={1920} height={1280} priority />)
+  test('Set `imageDir` and `filenameGenerator` and `convertFormat` and `sourceImageParser`', () => {
+    render(<CustomImage src="/images/img&ext=png" width={1920} height={1280} priority />)
 
     expect(screen.getByRole('img')).toHaveAttribute('src', '/base-path/_custom-optimize/images-img.3840.75.webp')
   })

--- a/docs/docs/04-Configurations/01-basic-configuration.md
+++ b/docs/docs/04-Configurations/01-basic-configuration.md
@@ -80,6 +80,11 @@ const config = {
 + 'images-sample.1920.75.png'
 ```
 
+#### ❗️Attention
+
+When making this setting, make sure that the file names (including the path part) of different images do not cover each other.  
+Specifically, include the name, width, quality, and extension in the return value. If path is not included, all src's should be specified with `import` or `require` so that they can be distinguished by their hash value even if they have the same filename.
+
 ### `sourceImageParser`
 
 - Type: function
@@ -125,11 +130,6 @@ const config = {
   },
 }
 ```
-
-#### ❗️Attention
-
-When making this setting, make sure that the file names (including the path part) of different images do not cover each other.  
-Specifically, include the name, width, quality, and extension in the return value. If path is not included, all src's should be specified with `import` or `require` so that they can be distinguished by their hash value even if they have the same filename.
 
 ### `sharpOptions`
 

--- a/docs/docs/04-Configurations/01-basic-configuration.md
+++ b/docs/docs/04-Configurations/01-basic-configuration.md
@@ -80,6 +80,52 @@ const config = {
 + 'images-sample.1920.75.png'
 ```
 
+### `sourceImageParser`
+
+- Type: function
+- Argument: Object
+- Return value: string
+
+The argument for this function will be an object of type
+
+```typescript
+{
+  src: string // The source images 'src' attribute
+  defaultParser: (src: string) => ParsedImageInfo // A function which evaluates the image name, path name (without image name appended and starting w/ '/'), and extension
+}
+```
+
+This might be useful if any of your images have URLs that do not follow the standard `https://somehost.com/imagename.extension` pattern.
+
+For example: Maybe your source image's src attribute is more like `https://somedigitalassetmangementhost.com?fileId=1234-xyze&extension=jpg`, so you might add the following to your config:
+
+**NOTE**
+This gets run before filenameGenerator, so the arguments passed into filenameGenerator would be affected by sourceImageParser configuration. (path, name, and extension)
+
+```typescript
+// export-images.config.js
+/**
+ * @type {import('../../src').Config}
+ */
+const config = {
+  sourceImageParser: ({ src, defaultParser }) => {
+    const regExpMatches = src.match(/^.*\?fileId=(.*)&extension=(\w*).*$/);
+    if (!regExpMatches) {
+      return defaultParser(src);
+    }
+
+    // if the src has fileId and extension in its route then it 
+    // must be a non-standard image, so parse it differently for all intents
+    // and purposes
+    return {
+      pathWithoutName: "", // maybe there is no path, or you can supply an arbitrary one for filename processing
+      name: regExpMatches[1] || "",
+      extension: regExpMatches[2] || "",
+    };
+  },
+}
+```
+
 #### ❗️Attention
 
 When making this setting, make sure that the file names (including the path part) of different images do not cover each other.  

--- a/docs/docs/04-Configurations/01-basic-configuration.md
+++ b/docs/docs/04-Configurations/01-basic-configuration.md
@@ -89,14 +89,24 @@ Specifically, include the name, width, quality, and extension in the return valu
 
 - Type: function
 - Argument: Object
-- Return value: string
+- Return value: ParsedImageInfo
 
-The argument for this function will be an object of type
+The argument for this function will be an object with the following shape:
 
 ```typescript
 {
   src: string // The source images 'src' attribute
   defaultParser: (src: string) => ParsedImageInfo // A function which evaluates the image name, path name (without image name appended and starting w/ '/'), and extension
+}
+```
+
+The return value for this function will be an object with the following shape (ParsedImageInfo type):
+
+```typescript
+{
+  pathWithoutName: string // The image path (not including the image name)
+  name: string // The image name
+  extension: string // The image extension
 }
 ```
 
@@ -110,7 +120,7 @@ This gets run before filenameGenerator, so the arguments passed into filenameGen
 ```typescript
 // export-images.config.js
 /**
- * @type {import('../../src').Config}
+ * @type {import('next-export-optimize-images').Config}
  */
 const config = {
   sourceImageParser: ({ src, defaultParser }) => {

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -4,11 +4,11 @@ import React from 'react'
 
 import type { Manifest } from './cli/types'
 import formatValidate from './cli/utils/formatValidate'
-import getConfig from './utils/getConfig'
+import getConfig, { ParsedImageInfo } from './utils/getConfig'
 
 const config = getConfig()
 
-const defaultImageParser = (src: string) => {
+const defaultImageParser: (src: string) => ParsedImageInfo = (src: string) => {
   const path = src.split(/\.([^.]*$)/)[0]
   const extension = src.split(/\.([^.]*$)/)[1]
 

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -8,6 +8,32 @@ import getConfig from './utils/getConfig'
 
 const config = getConfig()
 
+const defaultImageParser = (src: string) => {
+  const path = src.split(/\.([^.]*$)/)[0]
+  const extension = src.split(/\.([^.]*$)/)[1]
+
+  if (!path || !extension) {
+    throw new Error(`Invalid path or no file extension: ${src}`)
+  }
+
+  let pathWithoutName = path.split('/').slice(0, -1).join('/')
+  const name = path.split('/').slice(-1).toString()
+
+  if (src.startsWith('http')) {
+    pathWithoutName = pathWithoutName
+      .replace(/^https?:\/\//, '')
+      .split('/')
+      .slice(1)
+      .join('/')
+  }
+
+  return {
+    pathWithoutName,
+    name,
+    extension,
+  }
+}
+
 const exportableLoader: ImageLoader = ({ src: _src, width, quality }) => {
   if (process.env.NODE_ENV === 'development') {
     // This doesn't bother optimizing in the dev environment. Next complains if the
@@ -21,11 +47,12 @@ const exportableLoader: ImageLoader = ({ src: _src, width, quality }) => {
     src = _src.replace(config.basePath, '')
   }
 
-  const path = src.split(/\.([^.]*$)/)[0]
-  let extension = src.split(/\.([^.]*$)/)[1]
-  if (!path || !extension) {
-    throw new Error(`Invalid path or no file extension: ${src}`)
-  }
+  const parsedImageInformation = config.sourceImageParser
+    ? config.sourceImageParser({ src, defaultParser: defaultImageParser })
+    : defaultImageParser(src)
+
+  let { extension } = parsedImageInformation
+  const { pathWithoutName, name } = parsedImageInformation
 
   if (config.convertFormat !== undefined) {
     const convertArray = config.convertFormat.find(([beforeConvert]) => beforeConvert === extension)
@@ -37,17 +64,6 @@ const exportableLoader: ImageLoader = ({ src: _src, width, quality }) => {
 
       extension = convertArray[1]
     }
-  }
-
-  let pathWithoutName = path.split('/').slice(0, -1).join('/')
-  const name = path.split('/').slice(-1).toString()
-
-  if (src.startsWith('http')) {
-    pathWithoutName = pathWithoutName
-      .replace(/^https?:\/\//, '')
-      .split('/')
-      .slice(1)
-      .join('/')
   }
 
   const outputDir = `/${

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -2,6 +2,12 @@ import type { AvifOptions, JpegOptions, PngOptions, WebpOptions } from 'sharp'
 
 import type { AllowedFormat } from '../cli/utils/formatValidate'
 
+export type ParsedImageInfo = {
+  pathWithoutName: string
+  name: string
+  extension: string
+}
+
 export type Config = {
   /**
    * Specify if you are customizing the default output directory, such as next export -o outDir.
@@ -57,6 +63,16 @@ export type Config = {
    * @type {[beforeConvert: AllowedFormat, afterConvert: AllowedFormat][]}
    */
   convertFormat?: [beforeConvert: AllowedFormat, afterConvert: AllowedFormat][]
+
+  /**
+   * Allows you to optionally override the parsed image information before optimized images.
+   *
+   * @type {({ src: string, default: (src: string) => object ) }) => object}
+   */
+  sourceImageParser?: (determinerProps: {
+    src: string
+    defaultParser: (src: string) => ParsedImageInfo
+  }) => ParsedImageInfo
 }
 
 const getConfig = (): Config => {


### PR DESCRIPTION
Add 'sourceImageParser' optional config entry to override path, name, and extension parsing logic of image src attributes.

✅Closes: 210

# Description

Allows consumers to specify an optional override for determining the path, name, and extension of source images.

This helps for source images that don't have standard URL formats such as https://host.com/image.jpg.

Maybe the source image URL is more like "https://some.dam.com?id=123&extension=jpg".

Fixes #210 

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I modified an existing config test to include testing this config option.

I ran yarn test to confirm no regression breakages.

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
