### PR TITLE
fix: 🐛 ENAMETOOLONG when using long filenames

### DIFF
--- a/__tests__/components/image/external-images/index.test.tsx
+++ b/__tests__/components/image/external-images/index.test.tsx
@@ -37,7 +37,7 @@ describe('External images', () => {
         externalUrl: 'https://next-export-optimize-images.vercel.app/sub-path/og.png',
         output: '/_next/static/chunks/images/sub-path/og_1920_75.webp',
         quality: 75,
-        src: '/_next/static/media/sub-path/og.png',
+        src: '/_next/static/media/8fcb025d6e036ec05907f2367ee713067a0c406c.png',
         width: 1920,
       },
       {
@@ -45,7 +45,7 @@ describe('External images', () => {
         externalUrl: 'https://next-export-optimize-images.vercel.app/sub-path/og.png',
         output: '/_next/static/chunks/images/sub-path/og_3840_75.webp',
         quality: 75,
-        src: '/_next/static/media/sub-path/og.png',
+        src: '/_next/static/media/8fcb025d6e036ec05907f2367ee713067a0c406c.png',
         width: 3840,
       },
     ])

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import { createHash } from 'crypto'
+
 import Image, { ImageLoader, ImageProps } from 'next/dist/client/image'
 import React from 'react'
 
@@ -10,7 +12,7 @@ const config = getConfig()
 
 const defaultImageParser: (src: string) => ParsedImageInfo = (src: string) => {
   const path = src.split(/\.([^.]*$)/)[0]
-  const extension = src.split(/\.([^.]*$)/)[1]
+  const extension = (src.split(/\.([^.]*$)/)[1] || '').split('?')[0]
 
   if (!path || !extension) {
     throw new Error(`Invalid path or no file extension: ${src}`)
@@ -52,7 +54,7 @@ const exportableLoader: ImageLoader = ({ src: _src, width, quality }) => {
     : defaultImageParser(src)
 
   let { extension } = parsedImageInformation
-  const { pathWithoutName, name } = parsedImageInformation
+  const { pathWithoutName, name, extension: originalExtension } = parsedImageInformation
 
   if (config.convertFormat !== undefined) {
     const convertArray = config.convertFormat.find(([beforeConvert]) => beforeConvert === extension)
@@ -84,11 +86,16 @@ const exportableLoader: ImageLoader = ({ src: _src, width, quality }) => {
     const path = require('path') as typeof import('path')
 
     if (src.startsWith('http')) {
-      json.src = `/${externalOutputDir}/${src
-        .replace(/^https?:\/\//, '')
-        .split('/')
-        .slice(1)
-        .join('/')}`
+      json.src = `/${externalOutputDir}/${createHash('sha1')
+        .update(
+          src
+            .replace(/^https?:\/\//, '')
+            .split('/')
+            .slice(1)
+            .join('/')
+        )
+        .digest('hex')}.${originalExtension}`
+
       json.externalUrl = src
     }
 


### PR DESCRIPTION
✅Closes: #309

# Description

Uses sha1 hash for filename when using external images.

Fixes #309 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

E2E test updated. But need a file with long name to test. Something from AWS S3 is perfect has it has a long parameters chain.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
