### PR TITLE
fix: 🐛 Removed crypto dependency from client bundle

### DIFF
--- a/__tests__/components/image/external-images/index.test.tsx
+++ b/__tests__/components/image/external-images/index.test.tsx
@@ -37,7 +37,7 @@ describe('External images', () => {
         externalUrl: 'https://next-export-optimize-images.vercel.app/sub-path/og.png',
         output: '/_next/static/chunks/images/sub-path/og_1920_75.webp',
         quality: 75,
-        src: '/_next/static/media/8fcb025d6e036ec05907f2367ee713067a0c406c.png',
+        src: '/_next/static/media/-803215824.png',
         width: 1920,
       },
       {
@@ -45,7 +45,7 @@ describe('External images', () => {
         externalUrl: 'https://next-export-optimize-images.vercel.app/sub-path/og.png',
         output: '/_next/static/chunks/images/sub-path/og_3840_75.webp',
         quality: 75,
-        src: '/_next/static/media/8fcb025d6e036ec05907f2367ee713067a0c406c.png',
+        src: '/_next/static/media/-803215824.png',
         width: 3840,
       },
     ])

--- a/src/image.tsx
+++ b/src/image.tsx
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { createHash } from 'crypto'
-
 import Image, { ImageLoader, ImageProps } from 'next/dist/client/image'
 import React from 'react'
 
@@ -9,6 +7,16 @@ import formatValidate from './cli/utils/formatValidate'
 import getConfig, { ParsedImageInfo } from './utils/getConfig'
 
 const config = getConfig()
+
+function hashCode(src: string) {
+  let hash = 0
+  for (let i = 0; i < src.length; i += 1) {
+    const chr = src.charCodeAt(i)
+    hash = (hash << 5) - hash + chr
+    hash |= 0 // Convert to 32bit integer
+  }
+  return `${hash}`
+}
 
 const defaultImageParser: (src: string) => ParsedImageInfo = (src: string) => {
   const path = src.split(/\.([^.]*$)/)[0]
@@ -86,15 +94,13 @@ const exportableLoader: ImageLoader = ({ src: _src, width, quality }) => {
     const path = require('path') as typeof import('path')
 
     if (src.startsWith('http')) {
-      json.src = `/${externalOutputDir}/${createHash('sha1')
-        .update(
-          src
-            .replace(/^https?:\/\//, '')
-            .split('/')
-            .slice(1)
-            .join('/')
-        )
-        .digest('hex')}.${originalExtension}`
+      json.src = `/${externalOutputDir}/${hashCode(
+        src
+          .replace(/^https?:\/\//, '')
+          .split('/')
+          .slice(1)
+          .join('/')
+      )}.${originalExtension}`
 
       json.externalUrl = src
     }


### PR DESCRIPTION
Uses hashCode instead of sha1 for external images

✅Closes: #332

# Description

Uses hashCode (local implementation) instead of sha1 to avoid including crypto-browserify in the bundle.

Fixes #332 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Test are passing and corrected.
Locally tested with my project without any issue.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
