### PR TITLE
feat: 🚀 expose page prop in filename generator

### DIFF
--- a/src/image.tsx
+++ b/src/image.tsx
@@ -1,10 +1,14 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import Image, { ImageLoader, ImageProps } from 'next/dist/client/image'
+import Image, { ImageProps as NextImageProps, ImageLoaderProps as NextImageLoaderProps } from 'next/dist/client/image'
 import React from 'react'
 
 import type { Manifest } from './cli/types'
 import formatValidate from './cli/utils/formatValidate'
 import getConfig, { DefaultImageParser } from './utils/getConfig'
+
+type ImageProps = NextImageProps & { 'data-page'?: string }
+type ImageLoaderProps = NextImageLoaderProps & { page: string }
+type ImageLoader = (p: ImageLoaderProps) => string
 
 const config = getConfig()
 
@@ -44,7 +48,7 @@ const defaultImageParser: DefaultImageParser = (src: string) => {
   }
 }
 
-const exportableLoader: ImageLoader = ({ src: _src, width, quality }) => {
+const exportableLoader: ImageLoader = ({ src: _src, width, quality, page }: ImageLoaderProps) => {
   if (process.env.NODE_ENV === 'development') {
     // This doesn't bother optimizing in the dev environment. Next complains if the
     // returned URL doesn't have a width in it, so adding it as a throwaway
@@ -82,9 +86,10 @@ const exportableLoader: ImageLoader = ({ src: _src, width, quality }) => {
   const externalOutputDir = `${
     config.externalImageDir ? config.externalImageDir.replace(/^\//, '').replace(/\/$/, '') : '_next/static/media'
   }`
+
   const filename =
     config.filenameGenerator !== undefined
-      ? config.filenameGenerator({ path: pathWithoutName, name, width, quality: quality || 75, extension })
+      ? config.filenameGenerator({ path: pathWithoutName, name, width, quality: quality || 75, extension, page })
       : `${pathWithoutName}/${name}_${width}_${quality || 75}.${extension}`
   const output = `${outputDir}/${filename.replace(/^\//, '')}`
 
@@ -115,14 +120,17 @@ const exportableLoader: ImageLoader = ({ src: _src, width, quality }) => {
 }
 
 const CustomImage = (props: ImageProps) => {
+  const loader = props.loader || exportableLoader
+  const page = props?.['data-page'] || ''
+
   return (
     <Image
       {...props}
-      loader={props.loader || exportableLoader}
+      loader={(loaderProps) => loader({ ...loaderProps, page })}
       blurDataURL={
         props.blurDataURL ||
         (typeof props.src === 'string' && props.placeholder === 'blur' && props.loader === undefined
-          ? exportableLoader({ src: props.src, width: 8, quality: 10 })
+          ? exportableLoader({ src: props.src, width: 8, quality: 10, page })
           : '')
       }
     />

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -53,6 +53,7 @@ export type Config = {
     width: number
     quality: number
     extension: string
+    page: string
   }) => string
   /**
    * You can set optimization options for each extension.


### PR DESCRIPTION
@dc7290 interested to hear your thoughts on this.

## Problem:
Image names matter for SEO. Googlebot uses image file names to extract information about subject matter and advises us to use filenames that are descriptive. Further information from Google [here](https://developers.google.com/search/docs/appearance/google-images#descriptive-titles-captions-filenames).

In one of my projects I load image files from a CDN that automatically generates hashed file names. These are non-descriptive and I want to automate renaming filenames for SEO as part of my build process.

I need to create unique filenames for each image on my site (as per the docs [here](https://next-export-optimize-images.vercel.app/docs/Configurations/basic-configuration#filenamegenerator)). Where things get difficult for me is that many pages of my website share the same images.

On the surface this wouldn't be a problem, except that for some reason Next.js tries to reload images from the old, incorrect source (prior to optimisation by this lib) on page change events. This is documented in this [open issue](https://github.com/dc7290/next-export-optimize-images/issues/385).

**I need a way to generate SEO friendly filenames that are truely unique for each image on my site.**

## Potential solution
Each image is rendered onto a page in my Nextjs site, and each page has a slug. If I can use the slug as a prop in my custom `filenameGenerator` then I can make a truely unique filename for each image that is human readable and SEO friendly.

This PR explores allowing a user to add a data-page="page-name" prop to their images. This value is then exposed as "page" in the custom filename generator and can be used for filename generation.

```
filenameGenerator?: (generatorProps: {
    path: string
    name: string
    width: number
    quality: number
    extension: string
    page: string
  }) => string
```

I'd be interested to hear your thoughts. Maybe there is a better way to achieve the same thing? Regarding the changes in this PR, I didn't find any tests that relate to this area of the code base. Maybe I was looking in the wrong place so if you can point me in the right direction I'd be happy to write tests.