### PR TITLE
docs: Fix typo on structure page

### DIFF
--- a/docs/docs/05-structure.md
+++ b/docs/docs/05-structure.md
@@ -69,7 +69,7 @@ Also, if you have set `deviceSizes` etc. in `next.config.js`, it is a little dif
 
 ## Image optimization
 
-Run `next-export-optimzie-images` to start optimizing the images.  
+Run `next-export-optimize-images` to start optimizing the images.  
 This is basically done after `yarn build && yarn export`.
 
 The image is optimized based on the information in the exported JSON file through the loader described earlier.  


### PR DESCRIPTION
# Description

Fixed a very minor typo in the docs! 
`next-export-optimzie-images` -> `next-export-optimize-images`

## Type of change

- [ ] Documentation fix
