### PR TITLE
feat/generateFormats for picture tag

### DIFF
--- a/__tests__/e2e/export-images.config.js
+++ b/__tests__/e2e/export-images.config.js
@@ -8,6 +8,7 @@ const config = {
     },
   },
   convertFormat: [['png', 'webp']],
+  generateFormats: ['jpg'],
   remoteImages: async () => ['https://next-export-optimize-images.vercel.app/og.png'],
   basePath: '/base',
 }

--- a/__tests__/e2e/index.test.ts
+++ b/__tests__/e2e/index.test.ts
@@ -15,6 +15,18 @@ const files = [
   // next/legacy/image
   '_next/static/media/legacy-img.8a5ad2fe_[width].webp',
   'images/legacy-img_[width].webp',
+
+  // generateFormats: ['jpg'],
+
+  // next/image
+  '_next/static/media/img.8a5ad2fe_[width].jpg',
+  'images/img_[width].jpg',
+  'og_[width].jpg',
+  'images/animated_[width].jpg',
+  '_next/static/media/client-only.8a5ad2fe_[width].jpg',
+  // next/legacyjpgge
+  '_next/static/media/legacy-img.8a5ad2fe_[width].jpg',
+  'images/legacy-img_[width].jpg',
 ]
 
 describe('`next build && next export && next-export-optimize-images` is executed correctly', () => {

--- a/__tests__/e2e/index.test.ts
+++ b/__tests__/e2e/index.test.ts
@@ -25,7 +25,7 @@ describe('`next build && next export && next-export-optimize-images` is executed
     const allSizes = [...configImages.imageSizes, ...configImages.deviceSizes]
     allSizes.forEach((size) => {
       files.forEach((file) => {
-        expect(exist(file.replace('[width]', size.toString()))).toBeTruthy
+        expect(exist(file.replace('[width]', size.toString()))).toBeTruthy()
       })
     })
   })

--- a/__tests__/utils/buildOutputInfo/index.test.ts
+++ b/__tests__/utils/buildOutputInfo/index.test.ts
@@ -11,13 +11,15 @@ describe('buildOutputInfo', () => {
 
     const output = buildOutputInfo(input)
 
-    expect(output).toEqual({
-      output: '/_next/static/chunks/images/_next/static/media/test_300.png',
-      src: '/_next/static/media/test.png',
-      extension: 'png',
-      originalExtension: 'png',
-      externalOutputDir: '_next/static/media',
-    })
+    expect(output).toEqual([
+      {
+        output: '/_next/static/chunks/images/_next/static/media/test_300.png',
+        src: '/_next/static/media/test.png',
+        extension: 'png',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+    ])
   })
 
   test('Default image parser functions properly (remote images)', () => {
@@ -29,13 +31,15 @@ describe('buildOutputInfo', () => {
 
     const output = buildOutputInfo(input)
 
-    expect(output).toEqual({
-      output: '/_next/static/chunks/images/images/test_300.png',
-      src: 'https://example.com/images/test.png',
-      extension: 'png',
-      originalExtension: 'png',
-      externalOutputDir: '_next/static/media',
-    })
+    expect(output).toEqual([
+      {
+        output: '/_next/static/chunks/images/images/test_300.png',
+        src: 'https://example.com/images/test.png',
+        extension: 'png',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+    ])
   })
 
   test('config.basePath is applied', () => {
@@ -49,13 +53,15 @@ describe('buildOutputInfo', () => {
 
     const output = buildOutputInfo(input)
 
-    expect(output).toEqual({
-      output: '/_next/static/chunks/images/_next/static/media/test_300.png',
-      src: '/_next/static/media/test.png',
-      extension: 'png',
-      originalExtension: 'png',
-      externalOutputDir: '_next/static/media',
-    })
+    expect(output).toEqual([
+      {
+        output: '/_next/static/chunks/images/_next/static/media/test_300.png',
+        src: '/_next/static/media/test.png',
+        extension: 'png',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+    ])
   })
 
   test('config.convertFormat is applied', () => {
@@ -69,13 +75,73 @@ describe('buildOutputInfo', () => {
 
     const output = buildOutputInfo(input)
 
-    expect(output).toEqual({
-      output: '/_next/static/chunks/images/_next/static/media/test_300.webp',
+    expect(output).toEqual([
+      {
+        output: '/_next/static/chunks/images/_next/static/media/test_300.webp',
+        src: '/_next/static/media/test.png',
+        extension: 'webp',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+    ])
+  })
+
+  test('config.generateFormats is applied', () => {
+    const input = {
       src: '/_next/static/media/test.png',
-      extension: 'webp',
-      originalExtension: 'png',
-      externalOutputDir: '_next/static/media',
-    })
+      width: 300,
+      config: {
+        generateFormats: ['jpg'],
+      } as Config,
+    }
+
+    const output = buildOutputInfo(input)
+
+    expect(output).toEqual([
+      {
+        output: '/_next/static/chunks/images/_next/static/media/test_300.png',
+        src: '/_next/static/media/test.png',
+        extension: 'png',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+      {
+        output: '/_next/static/chunks/images/_next/static/media/test_300.jpg',
+        src: '/_next/static/media/test.png',
+        extension: 'jpg',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+    ])
+  })
+
+  test('config.generateFormats ignores duplicate extensions', () => {
+    const input = {
+      src: '/_next/static/media/test.png',
+      width: 300,
+      config: {
+        generateFormats: ['jpg', 'png', 'jpg'],
+      } as Config,
+    }
+
+    const output = buildOutputInfo(input)
+
+    expect(output).toEqual([
+      {
+        output: '/_next/static/chunks/images/_next/static/media/test_300.png',
+        src: '/_next/static/media/test.png',
+        extension: 'png',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+      {
+        output: '/_next/static/chunks/images/_next/static/media/test_300.jpg',
+        src: '/_next/static/media/test.png',
+        extension: 'jpg',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+    ])
   })
 
   test('config.filenameGenerator is applied', () => {
@@ -89,13 +155,15 @@ describe('buildOutputInfo', () => {
 
     const output = buildOutputInfo(input)
 
-    expect(output).toEqual({
-      output: '/_next/static/chunks/images/_next/static/media/test-300.png',
-      src: '/_next/static/media/test.png',
-      extension: 'png',
-      originalExtension: 'png',
-      externalOutputDir: '_next/static/media',
-    })
+    expect(output).toEqual([
+      {
+        output: '/_next/static/chunks/images/_next/static/media/test-300.png',
+        src: '/_next/static/media/test.png',
+        extension: 'png',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+    ])
   })
 
   test('config.imageDir and config.externalImageDir is applied', () => {
@@ -110,13 +178,15 @@ describe('buildOutputInfo', () => {
 
     const output = buildOutputInfo(input)
 
-    expect(output).toEqual({
-      output: '/custom/images/_next/static/media/test_300.png',
-      src: '/_next/static/media/test.png',
-      extension: 'png',
-      originalExtension: 'png',
-      externalOutputDir: 'custom/external',
-    })
+    expect(output).toEqual([
+      {
+        output: '/custom/images/_next/static/media/test_300.png',
+        src: '/_next/static/media/test.png',
+        extension: 'png',
+        originalExtension: 'png',
+        externalOutputDir: 'custom/external',
+      },
+    ])
   })
 
   test('Unauthorized format in config.convertFormat throws an error', () => {
@@ -130,6 +200,20 @@ describe('buildOutputInfo', () => {
 
     expect(() => buildOutputInfo(input)).toThrowError(
       new Error(`Unauthorized format specified in \`configFormat\`. afterConvert: invalid_format`)
+    )
+  })
+
+  test('Unauthorized extension in config.generateFormats throws an error', () => {
+    const input = {
+      src: '/_next/static/media/test.png',
+      width: 300,
+      config: {
+        generateFormats: ['invalid_format'],
+      } as unknown as Config,
+    }
+
+    expect(() => buildOutputInfo(input)).toThrowError(
+      new Error(`Unauthorized extension specified in \`generateFormats\`: invalid_format`)
     )
   })
 
@@ -155,12 +239,14 @@ describe('buildOutputInfo', () => {
       defaultParser: expect.any(Function),
     })
 
-    expect(output).toEqual({
-      output: '/_next/static/chunks/images/custom/test_300.png',
-      src: '/_next/static/media/test.png',
-      extension: 'png',
-      originalExtension: 'png',
-      externalOutputDir: '_next/static/media',
-    })
+    expect(output).toEqual([
+      {
+        output: '/_next/static/chunks/images/custom/test_300.png',
+        src: '/_next/static/media/test.png',
+        extension: 'png',
+        originalExtension: 'png',
+        externalOutputDir: '_next/static/media',
+      },
+    ])
   })
 })

--- a/docs/docs/04-Configurations/01-basic-configuration.md
+++ b/docs/docs/04-Configurations/01-basic-configuration.md
@@ -195,6 +195,32 @@ const config = {
 
 The original image will be kept, `img.png` will be converted to webp format and `img.jpg` will be converted to avif format and output to the directory.
 
+### `generateFormats`
+
+- Type: Array\<Format>  
+  Format → "jpeg" | "jpg" | "png" | "webp" | "avif"
+
+It allows you to generate extra images in extensions specified.
+
+e.g. 
+
+```js
+const config = {
+  generateFormats: ['jpg'],
+}
+```
+
+```jsx
+<Image src="/img.webp" width={1280} height={640} alt="" />
+<Image src="/img.jpg" width={1280} height={640} alt="" />
+```
+
+
+The original image is `img.webp`. New image `img.jpg` is generated and output to the directory.
+Generated images can be served in two ways:
+- A picture tag
+- A server that rewrites url based on HTTP request Accept header
+
 ### `remoteImages`
 
 - Type: Array<string\> | (() => Array<string\> | Promise<Array<string\>\>)

--- a/docs/docs/04-Configurations/01-basic-configuration.md
+++ b/docs/docs/04-Configurations/01-basic-configuration.md
@@ -197,7 +197,7 @@ The original image will be kept, `img.png` will be converted to webp format and 
 
 ### `generateFormats`
 
-- Type: Array\<Format>  
+- Type: Array<Format\>  
   Format → "jpeg" | "jpg" | "png" | "webp" | "avif"
 
 It allows you to generate extra images in extensions specified.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -187,31 +187,32 @@ export const optimizeImages = async ({
       Array.from(remoteImageList)
         .map((url) =>
           allSizes.map((size) => {
-            const { output, extension, originalExtension, externalOutputDir } = buildOutputInfo({
+            return buildOutputInfo({
               src: url,
               width: size,
               config,
-            })
-            const json: Manifest[number] = {
-              output,
-              src: `/${externalOutputDir}/${createHash('sha256')
-                .update(
-                  url
-                    .replace(/^https?:\/\//, '')
-                    .split('/')
-                    .slice(1)
-                    .join('/')
-                )
-                .digest('hex')}.${originalExtension}`,
-              width: size,
-              extension,
-              externalUrl: url,
-            }
+            }).map(({ output, extension, originalExtension, externalOutputDir }) => {
+              const json: Manifest[number] = {
+                output,
+                src: `/${externalOutputDir}/${createHash('sha256')
+                  .update(
+                    url
+                      .replace(/^https?:\/\//, '')
+                      .split('/')
+                      .slice(1)
+                      .join('/')
+                  )
+                  .digest('hex')}.${originalExtension}`,
+                width: size,
+                extension,
+                externalUrl: url,
+              }
 
-            return json
+              return json
+            })
           })
         )
-        .flat()
+        .flat(2)
     )
   }
   if (manifest.some(({ externalUrl }) => externalUrl !== undefined)) {
@@ -232,22 +233,23 @@ export const optimizeImages = async ({
         .map((file) =>
           allSizes.map((size) => {
             const src = file.replace(publicDir, '')
-            const { output, extension } = buildOutputInfo({
+            return buildOutputInfo({
               src,
               width: size,
               config,
-            })
-            const json: Manifest[number] = {
-              output,
-              src,
-              width: size,
-              extension,
-            }
+            }).map(({ output, extension }) => {
+              const json: Manifest[number] = {
+                output,
+                src,
+                width: size,
+                extension,
+              }
 
-            return json
+              return json
+            })
           })
         )
-        .flat()
+        .flat(2)
     )
   }
 

--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -13,7 +13,7 @@ const exportableLoader: ImageLoader = ({ src, width }) => {
     return `${src}?width=${width}`
   }
 
-  const { output } = buildOutputInfo({ src, width, config })
+  const { output } = buildOutputInfo({ src, width, config })[0] ?? { output: `${src}?width=${width}` }
 
   return `${config.basePath ?? ''}${output}`
 }

--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -6,7 +6,7 @@ import getConfig from '../utils/getConfig'
 
 const config = getConfig()
 
-const exportableLoader: ImageLoader = ({ src, width }) => {
+export const exportableLoader: ImageLoader = ({ src, width }) => {
   if (process.env['NODE_ENV'] === 'development') {
     // This doesn't bother optimizing in the dev environment. Next complains if the
     // returned URL doesn't have a width in it, so adding it as a throwaway

--- a/src/components/legacy-image.tsx
+++ b/src/components/legacy-image.tsx
@@ -13,7 +13,7 @@ const exportableLoader: ImageLoader = ({ src, width }) => {
     return `${src}?width=${width}`
   }
 
-  const { output } = buildOutputInfo({ src, width, config })
+  const { output } = buildOutputInfo({ src, width, config })[0] ?? { output: `${src}?width=${width}` }
 
   return `${config.basePath ?? ''}${output}`
 }

--- a/src/components/legacy-image.tsx
+++ b/src/components/legacy-image.tsx
@@ -6,7 +6,7 @@ import getConfig from '../utils/getConfig'
 
 const config = getConfig()
 
-const exportableLoader: ImageLoader = ({ src, width }) => {
+export const exportableLoader: ImageLoader = ({ src, width }) => {
   if (process.env['NODE_ENV'] === 'development') {
     // This doesn't bother optimizing in the dev environment. Next complains if the
     // returned URL doesn't have a width in it, so adding it as a throwaway

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -37,18 +37,19 @@ export default async function loader(this: LoaderContext<LoaderOptions>, content
   if (!src.endsWith('.svg')) {
     await Promise.all(
       allSizes.map(async (size) => {
-        const outputInfo = buildOutputInfo({ src, width: size, config })
-        const json: Manifest[number] = {
-          output: outputInfo.output,
-          src: outputInfo.src,
-          width: size,
-          extension: outputInfo.extension,
-        }
+        buildOutputInfo({ src, width: size, config }).forEach((outputInfo) => {
+          const json: Manifest[number] = {
+            output: outputInfo.output,
+            src: outputInfo.src,
+            width: size,
+            extension: outputInfo.extension,
+          }
 
-        fs.appendFile(
-          path.join(process.cwd(), '.next/next-export-optimize-images-list.nd.json'),
-          JSON.stringify(json) + '\n'
-        )
+          fs.appendFile(
+            path.join(process.cwd(), '.next/next-export-optimize-images-list.nd.json'),
+            JSON.stringify(json) + '\n'
+          )
+        })
       })
     )
   }

--- a/src/utils/buildOutputInfo.ts
+++ b/src/utils/buildOutputInfo.ts
@@ -65,13 +65,20 @@ const buildOutputInfo = ({ src: _src, width, config }: BuildOutputInfoArgs) => {
   const externalOutputDir = `${
     config.externalImageDir ? config.externalImageDir.replace(/^\//, '').replace(/\/$/, '') : '_next/static/media'
   }`
-  const filename =
-    config.filenameGenerator !== undefined
-      ? config.filenameGenerator({ path: pathWithoutName, name, width, extension })
-      : `${pathWithoutName}/${name}_${width}.${extension}`
-  const output = `${outputDir}/${filename.replace(/^\//, '')}`
 
-  return { output, src, extension, originalExtension, externalOutputDir }
+  const extensions = config.generateFormats ? [...new Set([extension, ...config.generateFormats])] : [extension]
+  return extensions.map((extension, index) => {
+    if (index > 0 && !formatValidate(extension))
+      throw Error(`Unauthorized extension specified in \`generateFormats\`: ${extension}`)
+
+    const filename =
+      config.filenameGenerator !== undefined
+        ? config.filenameGenerator({ path: pathWithoutName, name, width, extension })
+        : `${pathWithoutName}/${name}_${width}.${extension}`
+    const output = `${outputDir}/${filename.replace(/^\//, '')}`
+
+    return { output, src, extension, originalExtension, externalOutputDir }
+  })
 }
 
 export default buildOutputInfo

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -73,6 +73,13 @@ export type Config = {
   convertFormat?: [beforeConvert: AllowedFormat, afterConvert: AllowedFormat][]
 
   /**
+   * You can generate extra images in extensions specified.
+   *
+   * @type {AllowedFormat[]}
+   */
+  generateFormats?: AllowedFormat[]
+
+  /**
    * Allows you to optionally override the parsed image information before optimized images.
    *
    * @type {SourceImageParser}


### PR DESCRIPTION
# Description

My main motivation was to be able to support serving multiple image formats. Either with a picture tag or by rewriting URL based on HTTP Accept header.

New config option.
```js
const config = {
  generateFormats: ['jpg'],
}
```

Fixes # (issue)
#666

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Modified e2e test configuration file. Added new generated files to the list.
The tests passed.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
