### PR TITLE
🚀 feat: add config for remote images download delays

### DIFF
--- a/docs/docs/03-Features/01-external-images.md
+++ b/docs/docs/03-Features/01-external-images.md
@@ -43,3 +43,11 @@ Also, no downloading to local is performed.
   src="https://next-export-optimize-images.vercel.app/og.png?width=3840"
 />
 ```
+
+### `remoteImagesDownloadsDelay`
+
+- Type: number
+
+In case you need to download a large amount of images from an external CDN with a rate limit, this will add delays between downloading images.
+
+effectively this will add `sleep` function between downloads.

--- a/docs/docs/04-Configurations/01-basic-configuration.md
+++ b/docs/docs/04-Configurations/01-basic-configuration.md
@@ -216,3 +216,9 @@ You can directly specify the URL of an external image.
 This is useful in cases where it is not known what images will be used for the build using variables, for example.
 
 https://next-export-optimize-images.vercel.app/docs/Features/external-images#when-specifying-an-external-image-url-with-a-variable
+
+### `remoteImagesDownloadsDelay`
+
+- Type: number
+
+In case you need to download a large amount of images from an external CDN with a rate limit, this will add delays between downloading images.

--- a/src/cli/external-images/index.ts
+++ b/src/cli/external-images/index.ts
@@ -5,13 +5,23 @@ import got from 'got'
 
 import type { Manifest } from '../'
 
+import type { Config } from './../../utils/getConfig'
+
 type ExternalImagesDownloaderArgs = {
   terse?: boolean
   manifest: Manifest
   destDir: string
+  remoteImagesDownloadsDelay?: Config['remoteImagesDownloadsDelay']
 }
 
-const externalImagesDownloader = async ({ terse = false, manifest, destDir }: ExternalImagesDownloaderArgs) => {
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const externalImagesDownloader = async ({
+  terse = false,
+  manifest,
+  destDir,
+  remoteImagesDownloadsDelay,
+}: ExternalImagesDownloaderArgs) => {
   if (!terse) {
     // eslint-disable-next-line no-console
     console.log('\n- Download external images -')
@@ -24,6 +34,10 @@ const externalImagesDownloader = async ({ terse = false, manifest, destDir }: Ex
     if (externalUrl === undefined) continue
 
     if (downloadedImages.some((image) => image === externalUrl)) continue
+
+    if (remoteImagesDownloadsDelay) {
+      await sleep(remoteImagesDownloadsDelay)
+    }
 
     promises.push(
       (async () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -174,8 +174,8 @@ export const optimizeImages = async ({
     config.remoteImages === undefined
       ? []
       : typeof config.remoteImages === 'function'
-      ? await config.remoteImages()
-      : config.remoteImages
+        ? await config.remoteImages()
+        : config.remoteImages
   if (remoteImages.length > 0) {
     const remoteImageList = new Set<string>()
 
@@ -216,7 +216,12 @@ export const optimizeImages = async ({
     )
   }
   if (manifest.some(({ externalUrl }) => externalUrl !== undefined)) {
-    await externalImagesDownloader({ terse, manifest, destDir })
+    await externalImagesDownloader({
+      terse,
+      manifest,
+      destDir,
+      remoteImagesDownloadsDelay: config.remoteImagesDownloadsDelay,
+    })
   }
 
   const publicDir = path.resolve(cwd, 'public')

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -96,6 +96,11 @@ export type Config = {
    * @type {string[] | (() => string[] | Promise<string[]>)}
    */
   remoteImages?: string[] | (() => string[] | Promise<string[]>)
+
+  /**
+   * In case you need to download a large amount of images from an external CDN with a rate limit, this will add delays between downloading images.
+   */
+  remoteImagesDownloadsDelay?: number
 }
 
 const getConfig = (): Config => {


### PR DESCRIPTION
# Description

This PR add configuration for downloading remote images from CDN with rate limits.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This new config is tested agains [Contentful](https://www.contentful.com/developers/docs/references/content-delivery-api/) image CDN that has limit 55 request/s.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
