### PR TITLE
fix: 🐛 Don't log spam configuration loaded log

### DIFF
--- a/src/withExportImages.ts
+++ b/src/withExportImages.ts
@@ -5,6 +5,9 @@ import fs from 'fs-extra'
 import type { NextConfig } from 'next'
 import type { Config } from './utils/getConfig'
 
+// Track whether the configuration message has been logged
+let configMessageLogged = false
+
 const withExportImages = async (
   nextConfig: NextConfig = {},
   options: { __test?: boolean } = {}
@@ -53,16 +56,19 @@ const withExportImages = async (
     )}`
   )
 
-  // eslint-disable-next-line no-console
-  console.log(
-    colors.magenta(
-      `info - [next-export-optimize-images]: ${
-        resolvedConfigPath !== null
-          ? `Configuration loaded from \`${resolvedConfigPath}\`.`
-          : 'Configuration was not loaded. (This is optional.)'
-      }`
+  if (!configMessageLogged) {
+    // eslint-disable-next-line no-console
+    console.log(
+      colors.magenta(
+        `info - [next-export-optimize-images]: ${
+          resolvedConfigPath !== null
+            ? `Configuration loaded from \`${resolvedConfigPath}\`.`
+            : 'Configuration was not loaded. (This is optional.)'
+        }`
+      )
     )
-  )
+    configMessageLogged = true
+  }
 
   const customConfig: NextConfig = {
     webpack(config, option) {


### PR DESCRIPTION
# Description

Prevents "info - [next-export-optimize-images]: Configuration loaded from `/path/to/export-images.config.js`." from printing 5 times when running build or dev server restarts. Now it only prints 2 times :D.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Observe that there is no more log spam when running dev server on next.js

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
