### PR TITLE
fix: 🐛 add next 16 + turbopack compatibility

### DIFF
--- a/__tests__/e2e-build/index.test.ts
+++ b/__tests__/e2e-build/index.test.ts
@@ -3,20 +3,45 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import { imageConfigDefault } from 'next/dist/shared/lib/image-config'
 
-const exist = (filename: string) => fs.existsSync(path.resolve(__dirname, '.next/static/chunks/images', filename))
+const optimizedImagesDir = path.resolve(__dirname, '.next/static/chunks/images')
+const listAll = (root: string): string[] => {
+  if (!fs.existsSync(root)) return []
+  const out: string[] = []
+  const stack: string[] = [root]
+  while (stack.length > 0) {
+    const cur = stack.pop()
+    if (cur === undefined) break
+    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+      const full = path.join(cur, entry.name)
+      if (entry.isDirectory()) stack.push(full)
+      else out.push(path.relative(root, full).split(path.sep).join('/'))
+    }
+  }
+  return out
+}
+const allOptimized = listAll(optimizedImagesDir)
+
+const HASH_SENTINEL = 'HASH'
+const WIDTH_SENTINEL = 'WIDTH'
+const exist = (pattern: string) => {
+  const tokenized = pattern.replace(/\[hash\]/g, HASH_SENTINEL).replace(/\[width\]/g, WIDTH_SENTINEL)
+  const escaped = tokenized.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  const reSrc = escaped.split(HASH_SENTINEL).join('[A-Za-z0-9_~.\\-]+').split(WIDTH_SENTINEL).join('\\d+')
+  return allOptimized.some((f) => new RegExp(`^${reSrc}$`).test(f))
+}
 
 const files = [
   // webp
 
   // next/image
-  '_next/static/media/img.8a5ad2fe_[width].webp',
+  '_next/static/media/img.[hash]_[width].webp',
   'id/237/200/300_[width].webp',
   'id/238/200/300_[width].webp',
 
   // png or jpg
 
   // next/image
-  '_next/static/media/img.8a5ad2fe_[width].png',
+  '_next/static/media/img.[hash]_[width].png',
   'id/237/200/300_[width].jpg',
   'id/238/200/300_[width].jpg',
 ]
@@ -28,9 +53,10 @@ describe('`next build && next export && next-export-optimize-images` is executed
     const allSizes = [...configImages.imageSizes, ...configImages.deviceSizes]
     for (const size of allSizes) {
       for (const file of files) {
-        const isExist = exist(file.replace('[width]', size.toString()))
+        const pattern = file.replace('[width]', size.toString())
+        const isExist = exist(pattern)
         if (!isExist) {
-          console.log(file.replace('[width]', size.toString()))
+          console.log(pattern)
         }
         expect(isExist).toBeTruthy()
       }

--- a/__tests__/e2e/index.test.ts
+++ b/__tests__/e2e/index.test.ts
@@ -3,65 +3,95 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import { imageConfigDefault } from 'next/dist/shared/lib/image-config'
 
-const exist = (filename: string) => fs.existsSync(path.resolve(__dirname, 'out/_next/static/chunks/images', filename))
+// Recursively walk the optimized-images output dir once and cache the results
+// so the per-pattern match below stays cheap.
+const optimizedImagesDir = path.resolve(__dirname, 'out/_next/static/chunks/images')
+const listAll = (root: string): string[] => {
+  if (!fs.existsSync(root)) return []
+  const out: string[] = []
+  const stack: string[] = [root]
+  while (stack.length > 0) {
+    const cur = stack.pop()
+    if (cur === undefined) break
+    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+      const full = path.join(cur, entry.name)
+      if (entry.isDirectory()) stack.push(full)
+      else out.push(path.relative(root, full).split(path.sep).join('/'))
+    }
+  }
+  return out
+}
+const allOptimized = listAll(optimizedImagesDir)
+
+// Patterns may contain `[hash]` (matches any contiguous hash segment Turbopack
+// or webpack emits — base36 chars plus `_~.-`) and `[width]` (replaced with the
+// specific width being checked).
+const HASH_SENTINEL = 'HASH'
+const WIDTH_SENTINEL = 'WIDTH'
+const exist = (pattern: string) => {
+  const tokenized = pattern.replace(/\[hash\]/g, HASH_SENTINEL).replace(/\[width\]/g, WIDTH_SENTINEL)
+  const escaped = tokenized.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  const reSrc = escaped.split(HASH_SENTINEL).join('[A-Za-z0-9_~.\\-]+').split(WIDTH_SENTINEL).join('\\d+')
+  return allOptimized.some((f) => new RegExp(`^${reSrc}$`).test(f))
+}
 
 const files = [
   // avif
 
   // next/image
-  '_next/static/media/img.8a5ad2fe_[width].avif',
-  '_next/static/media/get-props.8a5ad2fe_[width].avif',
-  '_next/static/media/get-props-mobile.7d5f5264_[width].avif',
+  '_next/static/media/img.[hash]_[width].avif',
+  '_next/static/media/get-props.[hash]_[width].avif',
+  '_next/static/media/get-props-mobile.[hash]_[width].avif',
   'images/img_[width].avif',
   'id/237/200/300_[width].avif',
   'id/238/200/300_[width].avif',
   'id/500/200/400_[width].avif',
   'images/animated_[width].avif',
-  '_next/static/media/client-only.8a5ad2fe_[width].avif',
+  '_next/static/media/client-only.[hash]_[width].avif',
   // next/legacy/image
-  '_next/static/media/legacy-img.8a5ad2fe_[width].avif',
+  '_next/static/media/legacy-img.[hash]_[width].avif',
   'images/legacy-img_[width].avif',
   // picture
-  '_next/static/media/picture.8a5ad2fe_[width].avif',
+  '_next/static/media/picture.[hash]_[width].avif',
   'images/picture_[width].avif',
 
   // webp
 
   // next/image
-  '_next/static/media/img.8a5ad2fe_[width].webp',
-  '_next/static/media/get-props.8a5ad2fe_[width].webp',
-  '_next/static/media/get-props-mobile.7d5f5264_[width].webp',
+  '_next/static/media/img.[hash]_[width].webp',
+  '_next/static/media/get-props.[hash]_[width].webp',
+  '_next/static/media/get-props-mobile.[hash]_[width].webp',
   'images/img_[width].webp',
   'id/237/200/300_[width].webp',
   'id/238/200/300_[width].webp',
   'id/500/200/400_[width].webp',
   'images/animated_[width].webp',
-  '_next/static/media/client-only.8a5ad2fe_[width].webp',
+  '_next/static/media/client-only.[hash]_[width].webp',
   // next/legacy/image
-  '_next/static/media/legacy-img.8a5ad2fe_[width].webp',
+  '_next/static/media/legacy-img.[hash]_[width].webp',
   'images/legacy-img_[width].webp',
   // picture
-  '_next/static/media/picture.8a5ad2fe_[width].webp',
+  '_next/static/media/picture.[hash]_[width].webp',
   'images/picture_[width].webp',
 
   // png or jpg
 
   // next/image
-  '_next/static/media/img.8a5ad2fe_[width].png',
-  '_next/static/media/get-props.8a5ad2fe_[width].png',
-  '_next/static/media/get-props-mobile.7d5f5264_[width].png',
+  '_next/static/media/img.[hash]_[width].png',
+  '_next/static/media/get-props.[hash]_[width].png',
+  '_next/static/media/get-props-mobile.[hash]_[width].png',
   'images/img_[width].png',
   'id/237/200/300_[width].jpg',
   'id/238/200/300_[width].jpg',
   'id/300/200/400_[width].jpg',
   'id/400/200/400_[width].jpg',
   'id/500/200/400_[width].jpg',
-  '_next/static/media/client-only.8a5ad2fe_[width].png',
+  '_next/static/media/client-only.[hash]_[width].png',
   // next/legacy/image
-  '_next/static/media/legacy-img.8a5ad2fe_[width].png',
+  '_next/static/media/legacy-img.[hash]_[width].png',
   'images/legacy-img_[width].png',
   // picture
-  '_next/static/media/picture.8a5ad2fe_[width].png',
+  '_next/static/media/picture.[hash]_[width].png',
   'images/picture_[width].png',
 ]
 
@@ -72,9 +102,10 @@ describe('`next build && next export && next-export-optimize-images` is executed
     const allSizes = [...configImages.imageSizes, ...configImages.deviceSizes]
     for (const size of allSizes) {
       for (const file of files) {
-        const isExist = exist(file.replace('[width]', size.toString()))
+        const pattern = file.replace('[width]', size.toString())
+        const isExist = exist(pattern)
         if (!isExist) {
-          console.log(file.replace('[width]', size.toString()))
+          console.log(pattern)
         }
         expect(isExist).toBeTruthy()
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@types/jest": "29.5.14",
         "@types/lodash.uniqwith": "4.5.9",
         "@types/node": "22.18.12",
-        "@types/react": "npm:types-react@rc",
+        "@types/react": "19.2.0",
         "@types/recursive-readdir": "2.2.4",
         "conventional-changelog-conventionalcommits": "6.1.0",
         "git-cz": "4.9.0",
@@ -41,7 +41,7 @@
         "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
         "lint-staged": "15.5.2",
-        "next": "15.5.18",
+        "next": "16.2.6",
         "npm-run-all2": "7.0.2",
         "react": "19.2.0",
         "react-dom": "19.2.0",
@@ -56,7 +56,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "next": "14.x || 15.x",
+        "next": "14.x || 15.x || 16.x",
         "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0",
         "react-dom": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
       }
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1529,9 +1529,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz",
-      "integrity": "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -1547,13 +1547,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.3"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.4.tgz",
-      "integrity": "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -1569,13 +1569,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.3"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -1589,9 +1589,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz",
-      "integrity": "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
@@ -1621,9 +1621,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz",
-      "integrity": "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
@@ -1637,9 +1637,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.3.tgz",
-      "integrity": "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
       "cpu": [
         "ppc64"
       ],
@@ -1652,10 +1652,26 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.3.tgz",
-      "integrity": "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
@@ -1669,9 +1685,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz",
-      "integrity": "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
@@ -1685,9 +1701,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.3.tgz",
-      "integrity": "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
@@ -1701,9 +1717,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz",
-      "integrity": "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
@@ -1717,9 +1733,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz",
-      "integrity": "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
@@ -1735,13 +1751,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.3"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz",
-      "integrity": "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
@@ -1757,13 +1773,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.3"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.4.tgz",
-      "integrity": "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
       ],
@@ -1779,13 +1795,35 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.3"
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.4.tgz",
-      "integrity": "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
@@ -1801,13 +1839,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.3"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz",
-      "integrity": "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
@@ -1823,13 +1861,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.3"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.4.tgz",
-      "integrity": "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
@@ -1845,13 +1883,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz",
-      "integrity": "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
@@ -1867,20 +1905,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.4.tgz",
-      "integrity": "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.5.0"
+        "@emnapi/runtime": "^1.7.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -1890,9 +1928,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.4.tgz",
-      "integrity": "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
       "cpu": [
         "arm64"
       ],
@@ -1909,9 +1947,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.4.tgz",
-      "integrity": "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -1928,9 +1966,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.4.tgz",
-      "integrity": "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -2632,16 +2670,16 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
-      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
-      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -2656,9 +2694,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
-      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -2673,16 +2711,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
-      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2693,16 +2728,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
-      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2713,16 +2745,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
-      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2733,16 +2762,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
-      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2753,9 +2779,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
-      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -2770,9 +2796,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
-      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -4024,11 +4050,11 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "name": "types-react",
-      "version": "19.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/types-react/-/types-react-19.0.0-rc.1.tgz",
-      "integrity": "sha512-RshndUfqTW6K3STLPis8BtAYCGOkMbtvYsi90gmVNDZBXUyUc5juf2PE9LfS/JmOlUIRO8cWTS/1MTnmhjDqyQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5880,9 +5906,9 @@
       "dev": true
     },
     "node_modules/detect-libc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
-      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -9812,14 +9838,15 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
-      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.18",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -9828,18 +9855,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+        "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.18",
-        "@next/swc-darwin-x64": "15.5.18",
-        "@next/swc-linux-arm64-gnu": "15.5.18",
-        "@next/swc-linux-arm64-musl": "15.5.18",
-        "@next/swc-linux-x64-gnu": "15.5.18",
-        "@next/swc-linux-x64-musl": "15.5.18",
-        "@next/swc-win32-arm64-msvc": "15.5.18",
-        "@next/swc-win32-x64-msvc": "15.5.18",
-        "sharp": "^0.34.3"
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -14294,15 +14321,15 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.4.tgz",
-      "integrity": "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.0",
-        "semver": "^7.7.2"
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -14311,28 +14338,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.4",
-        "@img/sharp-darwin-x64": "0.34.4",
-        "@img/sharp-libvips-darwin-arm64": "1.2.3",
-        "@img/sharp-libvips-darwin-x64": "1.2.3",
-        "@img/sharp-libvips-linux-arm": "1.2.3",
-        "@img/sharp-libvips-linux-arm64": "1.2.3",
-        "@img/sharp-libvips-linux-ppc64": "1.2.3",
-        "@img/sharp-libvips-linux-s390x": "1.2.3",
-        "@img/sharp-libvips-linux-x64": "1.2.3",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.3",
-        "@img/sharp-linux-arm": "0.34.4",
-        "@img/sharp-linux-arm64": "0.34.4",
-        "@img/sharp-linux-ppc64": "0.34.4",
-        "@img/sharp-linux-s390x": "0.34.4",
-        "@img/sharp-linux-x64": "0.34.4",
-        "@img/sharp-linuxmusl-arm64": "0.34.4",
-        "@img/sharp-linuxmusl-x64": "0.34.4",
-        "@img/sharp-wasm32": "0.34.4",
-        "@img/sharp-win32-arm64": "0.34.4",
-        "@img/sharp-win32-ia32": "0.34.4",
-        "@img/sharp-win32-x64": "0.34.4"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -2,13 +2,7 @@
   "name": "next-export-optimize-images",
   "version": "4.6.2",
   "description": "Optimize images at build time with Next.js.",
-  "keywords": [
-    "next.js",
-    "static",
-    "export",
-    "image",
-    "optimization"
-  ],
+  "keywords": ["next.js", "static", "export", "image", "optimization"],
   "homepage": "https://next-export-optimize-images.vercel.app",
   "bugs": {
     "url": "https://github.com/dc7290/next-export-optimize-images/issues"
@@ -52,9 +46,7 @@
     "typecheck": "tsc --noEmit"
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
-      "biome check --write"
-    ]
+    "*.{ts,tsx}": ["biome check --write"]
   },
   "dependencies": {
     "ansi-colors": "^4.1.3",
@@ -78,7 +70,7 @@
     "@types/jest": "29.5.14",
     "@types/lodash.uniqwith": "4.5.9",
     "@types/node": "22.18.12",
-    "@types/react": "npm:types-react@rc",
+    "@types/react": "19.2.0",
     "@types/recursive-readdir": "2.2.4",
     "conventional-changelog-conventionalcommits": "6.1.0",
     "git-cz": "4.9.0",
@@ -86,7 +78,7 @@
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "lint-staged": "15.5.2",
-    "next": "15.5.18",
+    "next": "16.2.6",
     "npm-run-all2": "7.0.2",
     "react": "19.2.0",
     "react-dom": "19.2.0",
@@ -98,7 +90,7 @@
     "webpack": "5.104.1"
   },
   "peerDependencies": {
-    "next": "14.x || 15.x",
+    "next": "14.x || 15.x || 16.x",
     "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0",
     "react-dom": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
   },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -245,6 +245,36 @@ export const optimizeImages = async ({
     })
   }
 
+  // Discover local images Next emitted under static/media. Under webpack the
+  // loader has already written matching entries to the NDJSON manifest; the
+  // final uniqueItems pass collapses them. Under Turbopack this walk is the
+  // only registration channel for local imports.
+  const mediaDir =
+    config.mode === 'build' ? path.resolve(cwd, '.next/static/media') : path.resolve(destDir, '_next/static/media')
+  if (fs.existsSync(mediaDir)) {
+    if (!terse) {
+      console.log('\n- Collect images in .next/static/media -')
+    }
+    const mediaFiles = await recursiveReadDir(mediaDir)
+    const mediaImages = mediaFiles.filter((file) => {
+      const ext = path.extname(file).toLowerCase()
+      return ext === '.png' || ext === '.jpg' || ext === '.jpeg' || ext === '.webp' || ext === '.avif' || ext === '.gif'
+    })
+    manifest = manifest.concat(
+      mediaImages
+        .map((file) => {
+          const src = `/_next/static/media/${path.relative(mediaDir, file).split(path.sep).join('/')}`
+          return allSizes.map((size) =>
+            buildOutputInfo({ src, width: size, config }).map(({ output, extension }) => {
+              const json: Manifest[number] = { output, src, width: size, extension }
+              return json
+            })
+          )
+        })
+        .flat(2)
+    )
+  }
+
   const publicDir = path.resolve(cwd, 'public')
   if (fs.existsSync(publicDir)) {
     if (!terse) {
@@ -286,6 +316,10 @@ export const optimizeImages = async ({
         .flat(2)
     )
   }
+
+  // Collapse any duplicate entries introduced by the media-dir walk overlapping
+  // with the webpack-loader-written manifest. No-op when there's no overlap.
+  manifest = uniqueItems(manifest)
 
   if (!terse) {
     console.log('\n- Image Optimization -')

--- a/src/withExportImages.ts
+++ b/src/withExportImages.ts
@@ -71,6 +71,11 @@ const withExportImages = async (
   }
 
   const customConfig: NextConfig = {
+    // Declares Turbopack intent so Next 16 doesn't error when the webpack
+    // callback below is present. Turbopack uses native image emission; the
+    // loader path below runs only under `next build --webpack` and the
+    // CLI's post-build media-dir walk covers the Turbopack case.
+    turbopack: { ...(nextConfig.turbopack ?? {}) },
     webpack(config, option) {
       const nextImageLoader = config.module.rules.find(
         ({ loader }: { loader?: string }) => loader === 'next-image-loader'


### PR DESCRIPTION
Note: AI was used heavily in the creation of this PR, but all code was reviewed by me.

# Description

Next.js 16 makes Turbopack the default bundler for `next build`. Turbopack ignores the `webpack(config, …)` callback in `next.config.js`, which is the hook this package previously relied on to register statically-imported local images (`import img from './foo.png'`) into its optimization manifest via a `next-image-loader` swap. The result on a default Next 16 build is that local image imports silently miss the manifest and no variants are emitted for them.

This PR moves local-image registration to a post-build step so it no longer depends on the bundler:

- The CLI walks `.next/static/media` (or `out/_next/static/media` for static exports) and synthesises manifest entries via `buildOutputInfo` for every `.png`/`.jpg`/`.jpeg`/`.webp`/`.avif`/`.gif` it finds.
- A final `uniqueItems` pass collapses any overlap with entries already written by the webpack loader, so the two channels compose safely.
- The webpack hook stays intact for users who opt out of Turbopack in Next 16+ via `next build --webpack`.
- An empty `turbopack: {}` block is declared in the returned `NextConfig` so Next 16 doesn't error on the coexisting `webpack` callback (any user-supplied `turbopack` config is preserved).
- Peer range widened: `next: 14.x || 15.x` → `14.x || 15.x || 16.x`.

Dependencies / dev bumps:

- `next` dev dependency bumped to `16.2.6`.
- `@types/react` switched off the `types-react@rc` alias to a stable `19.2.0`.

Fixes #1276 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The e2e suites were updated to be hash-agnostic, because Turbopack and webpack emit different hash schemes in `_next/static/media/*` filenames:

- Expected filenames use `[hash]` and `[width]` tokens.
- The matcher does one recursive walk of the optimized-images output directory and regex-matches each pattern against the cached listing (`[hash]` → `[A-Za-z0-9_~.-]+`, `[width]` → `\d+`).

Run locally:

```bash
npm test | tee ./test-output.txt
```

This exercises:

- `__tests__/e2e/` — `next build && next-export-optimize-images` static export flow, verifying variants are emitted for `_next/static/media/*` imports under the default (Turbopack) bundler.
- `__tests__/e2e-build/` — non-export build flow, same verification.

Test configuration:

- Next.js `16.2.6` (Turbopack default) for the primary run.
- Also verified the webpack opt-out path (`next build --webpack`) still emits the same manifest entries via the loader, with the dedupe step keeping output identical.
- Peer install resolves cleanly against Next `14.x`, `15.x`, and `16.x` consumers.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# Research summary

Before settling on the post-build walk, the alternatives were investigated empirically against Next.js 16.2.6 with Turbopack as the default bundler. Findings:

**What broke and why.** Under Turbopack the `webpack(config, …)` callback never runs, so the package's `next-image-loader` swap — its sole channel for registering `import img from './foo.png'` into the NDJSON manifest — silently no-ops. Remote-image and `public/` flows are unaffected; only statically-imported local images regress.

**What an ideal compile-time hook would need.** Fire per image import, expose the absolute source path AND the final hashed `src` Next will emit (e.g. `/_next/static/media/<name>.<hash>.<ext>`), allow side effects to the manifest file, run only in production. The third property — visibility of Next's emitted `src` — is the one no current Turbopack surface provides.

**Options tested:**

| Approach | Outcome |
|---|---|
| `turbopack.rules` loader returning content (no `as:`) | Build fails — Turbopack UTF-8-coerces binary input before the loader sees it (`Invalid PNG signature`). |
| `turbopack.rules` loader, `fs.readFile(this.resourcePath)` + return Buffer | Works as a side-effect channel, but the loader runs **before** Next's hashing, so it can't write a complete manifest entry. Would still need a post-build reconcile. |
| `turbopack.rules` loader manually invoking the internal `next-image-loader` with a shimmed `emitFile` | Works and produces real StaticImageData, but **~3× slower** on real photo-sized assets (264 MB fixture: ~3.16 s native vs ~9.30 s composed) and couples to an internal Next path. Rejected. |
| Build Adapter `onBuildComplete` (`outputs.staticFiles`) | Gives a clean post-build inventory, but `adapterPath` is single-slot and would conflict with platform adapters (Vercel/Netlify). Same information as the directory walk, more ceremony. Rejected for the default path. |
| SWC WASM plugin | Can't see Next's hashed `src` at compile time either, has no FS access, heavy maintenance burden. Rejected. |
| Server-component `<LocalImage>` wrapper | Misses conditional/non-rendered branches, raw `<img>`, CSS backgrounds. Would require a user-API change. Rejected as the primary mechanism. |

**Turbopack documented limits confirmed in testing:**

- `emitFile` — unsupported in loader context.
- `importModule` / `loadModule` / `resolve` — unsupported.
- `fs` — only `fs.readFile` is implemented.
- "Loaders that transform files like stylesheets or images are not currently supported" (Next docs).

**Why the post-build walk wins.** It survives the Turbopack bundler swap without coupling to any internal Next path, doesn't consume `adapterPath`, doesn't pay the ~3× perf cost of recomposing `next-image-loader`, and preserves the existing URL contract — `path.relative(destDir, walkedFile) === StaticImageData.src.slice(1)` holds empirically in Next 16.2.6. Its only brittleness is silent failure if Next ever moves the emission path; that's an acceptable tradeoff given the alternatives, and is easy to detect with a future correlation check (compile-time import recording vs. post-build walk).